### PR TITLE
fix: build the Vite app for Pages (stop serving raw /src source)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,46 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+      - run: pnpm install
+      - run: pnpm run build
+        env:
+          GITHUB_PAGES: 'true'
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/deploy-pages@v4
+        id: deployment

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,6 +10,7 @@ const projectRoot = process.env.PROJECT_ROOT || import.meta.dirname
 
 // https://vite.dev/config/
 export default defineConfig({
+  base: process.env.GITHUB_PAGES ? '/classroom-rpg-aetheria/' : '/',
   plugins: [
     react(),
     tailwindcss(),
@@ -38,5 +39,14 @@ export default defineConfig({
     alias: {
       '@': resolve(projectRoot, 'src')
     }
+  },
+  // Expose the Pages build flag so client code can skip unavailable backend calls.
+  define: {
+    __GITHUB_PAGES__: !!process.env.GITHUB_PAGES,
+  },
+  // Disable lightningcss CSS minification — Tailwind v4 generates
+  // @media (width >= (display-mode: standalone)) which lightningcss cannot parse.
+  build: {
+    cssMinify: false,
   },
 });


### PR DESCRIPTION
## Summary

- **`vite.config.ts`**: sets `base: process.env.GITHUB_PAGES ? '/classroom-rpg-aetheria/' : '/'` so built assets reference `/classroom-rpg-aetheria/assets/...` instead of `/src/...`; adds `cssMinify: false` to work around a Tailwind v4 + lightningcss incompatibility with the `pwa` raw media query (`display-mode: standalone`) that causes a build crash; exposes `__GITHUB_PAGES__` define flag for client code
- **`.github/workflows/pages.yml`**: new workflow — checkout → pnpm install → `GITHUB_PAGES=true pnpm run build` → upload `dist/` via `actions/upload-pages-artifact` → deploy via `actions/deploy-pages` (same pattern as organvm/search-local--happy-hour PRs #48/#51)

## Local build confirmation

```
GITHUB_PAGES=true pnpm run build
✓ 7176 modules transformed.
dist/index.html  ← references /classroom-rpg-aetheria/assets/index-CUe5eIu_.js
                    references /classroom-rpg-aetheria/assets/index-2x5wl4Jz.css
✓ built in 1.02s
```

No `/src/...` references in dist output.

## Post-merge: switch Pages source to workflow

After this merges and the `Deploy to GitHub Pages` workflow runs successfully, switch Pages from legacy (branch root) to Actions:

```bash
gh api -X PUT repos/organvm/classroom-rpg-aetheria/pages \
  -f build_type=workflow
```

This requires org-owner or admin permission on the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)