### PR TITLE
fix: guard doomed backend requests on the static deploy (kills ~79 console errors)

### DIFF
--- a/src/lib/static-spark/hooks.ts
+++ b/src/lib/static-spark/hooks.ts
@@ -1,0 +1,84 @@
+/**
+ * Static (GitHub Pages) shim for `@github/spark/hooks`.
+ *
+ * On the static Pages build there is NO Spark runtime backend, so the real
+ * `useKV` — which fetches `/_spark/kv` and `/_spark/kv/<key>` on mount — would
+ * produce a 404 for every persisted key (dozens of console errors on load).
+ *
+ * This shim provides an identical `useKV` surface backed by `localStorage`,
+ * so persistence still works for a single visitor and NO network request is
+ * ever made. It is swapped in at build time via `resolve.alias` in
+ * `vite.config.ts`, gated on `GITHUB_PAGES` — normal/dev builds use the real
+ * Spark hooks unchanged.
+ */
+
+import { useCallback, useEffect, useState } from 'react'
+
+const STORAGE_PREFIX = 'spark-kv:'
+
+function readStored<T>(key: string): T | undefined {
+  try {
+    const raw = localStorage.getItem(STORAGE_PREFIX + key)
+    return raw === null ? undefined : (JSON.parse(raw) as T)
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * localStorage-backed drop-in replacement for `@github/spark/hooks`'s `useKV`.
+ *
+ * Signature matches the real hook exactly:
+ *   const [value, setValue, deleteValue] = useKV(key, initialValue)
+ */
+export function useKV<T = string>(
+  key: string,
+  initialValue?: T
+): readonly [T | undefined, (newValue: T | ((oldValue?: T) => T)) => void, () => void] {
+  const [value, setValue] = useState<T | undefined>(() => {
+    const stored = readStored<T>(key)
+    return stored !== undefined ? stored : initialValue
+  })
+
+  // Keep in sync across tabs.
+  useEffect(() => {
+    const onStorage = (e: StorageEvent) => {
+      if (e.key === STORAGE_PREFIX + key) {
+        setValue(e.newValue === null ? initialValue : (JSON.parse(e.newValue) as T))
+      }
+    }
+    window.addEventListener('storage', onStorage)
+    return () => window.removeEventListener('storage', onStorage)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [key])
+
+  const setKV = useCallback(
+    (newValue: T | ((oldValue?: T) => T)) => {
+      setValue((prev) => {
+        const next =
+          typeof newValue === 'function'
+            ? (newValue as (oldValue?: T) => T)(prev)
+            : newValue
+        try {
+          localStorage.setItem(STORAGE_PREFIX + key, JSON.stringify(next))
+        } catch {
+          // Storage full / disabled — value still lives in React state.
+        }
+        return next
+      })
+    },
+    [key]
+  )
+
+  const deleteKV = useCallback(() => {
+    try {
+      localStorage.removeItem(STORAGE_PREFIX + key)
+    } catch {
+      /* no-op */
+    }
+    setValue(initialValue)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [key])
+
+  return [value, setKV, deleteKV] as const
+}

--- a/src/lib/static-spark/spark.ts
+++ b/src/lib/static-spark/spark.ts
@@ -1,0 +1,108 @@
+/**
+ * Static (GitHub Pages) shim for `@github/spark/spark`.
+ *
+ * The real side-effect module, on import, unconditionally:
+ *   - POSTs to `/_spark/loaded`               → 405 on a static host
+ *   - installs `window.spark.kv`  (→ `/_spark/kv/*`   404s)
+ *   - installs `window.spark.user` (→ `/_spark/user`  404)
+ *   - installs `window.spark.llm`  (→ `/_spark/llm`   405)
+ *   - registers a heartbeat error listener that fetches source maps (404)
+ *
+ * On the static Pages build there is no Spark runtime, so every one of those
+ * calls fails and floods the console. This shim installs a fully local,
+ * network-free `window.spark`:
+ *   - `kv` is backed by `localStorage`
+ *   - `user` returns a static anonymous identity
+ *   - `llm` / `llmPrompt` degrade gracefully (no backend to call)
+ *
+ * It is swapped in at build time via `resolve.alias` in `vite.config.ts`,
+ * gated on `GITHUB_PAGES`. Normal/dev builds import the real runtime unchanged.
+ */
+
+const STORAGE_PREFIX = 'spark-kv:'
+
+function llmPrompt(strings: TemplateStringsArray | string[], ...values: unknown[]): string {
+  return (strings as ReadonlyArray<string>).reduce(
+    (acc, str, i) => acc + str + (i < values.length ? String(values[i]) : ''),
+    ''
+  )
+}
+
+/**
+ * No backend on a static host. Rather than throwing an unhandled 405, return a
+ * clear, JSON-safe message so callers (quest evaluation, content generation)
+ * degrade gracefully instead of erroring in the console.
+ */
+async function llm(_prompt: string, _modelName?: string, jsonMode?: boolean): Promise<string> {
+  const message =
+    'AI features are unavailable on the static demo deployment (no backend). ' +
+    'Run the app with a configured Spark or Firebase backend to enable them.'
+  if (jsonMode) {
+    return JSON.stringify({ error: 'ai_unavailable_static', message })
+  }
+  return message
+}
+
+const kv = {
+  keys: async (): Promise<string[]> => {
+    const out: string[] = []
+    try {
+      for (let i = 0; i < localStorage.length; i++) {
+        const k = localStorage.key(i)
+        if (k && k.startsWith(STORAGE_PREFIX)) out.push(k.slice(STORAGE_PREFIX.length))
+      }
+    } catch {
+      /* localStorage unavailable */
+    }
+    return out
+  },
+  get: async <T>(key: string): Promise<T | undefined> => {
+    try {
+      const raw = localStorage.getItem(STORAGE_PREFIX + key)
+      return raw === null ? undefined : (JSON.parse(raw) as T)
+    } catch {
+      return undefined
+    }
+  },
+  set: async <T>(key: string, value: T): Promise<void> => {
+    try {
+      localStorage.setItem(STORAGE_PREFIX + key, JSON.stringify(value))
+    } catch {
+      /* storage full / disabled */
+    }
+  },
+  delete: async (key: string): Promise<void> => {
+    try {
+      localStorage.removeItem(STORAGE_PREFIX + key)
+    } catch {
+      /* no-op */
+    }
+  },
+}
+
+async function user() {
+  return {
+    avatarUrl: '',
+    email: '',
+    id: 'static-anonymous',
+    isOwner: false,
+    login: 'anonymous',
+  }
+}
+
+declare global {
+  interface Window {
+    spark: {
+      llmPrompt: typeof llmPrompt
+      llm: typeof llm
+      user: typeof user
+      kv: typeof kv
+    }
+  }
+}
+
+if (typeof window !== 'undefined') {
+  window.spark = { llmPrompt, llm, user, kv }
+}
+
+export {}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,6 +7,20 @@ import createIconImportProxy from "@github/spark/vitePhosphorIconProxyPlugin";
 import { resolve } from 'path'
 
 const projectRoot = process.env.PROJECT_ROOT || import.meta.dirname
+const isPages = !!process.env.GITHUB_PAGES
+
+// On the static GitHub Pages build there is no Spark runtime backend, so the
+// real `@github/spark/spark` side-effect (POST /_spark/loaded) and every
+// `useKV` call (GET /_spark/kv/*) would 404/405 on load — dozens of console
+// errors. Swap those two modules for network-free, localStorage-backed shims
+// at build time. Only active when GITHUB_PAGES is set; dev/normal builds are
+// untouched and keep the real Spark runtime.
+const sparkPagesAliases = isPages
+  ? {
+      '@github/spark/spark': resolve(projectRoot, 'src/lib/static-spark/spark.ts'),
+      '@github/spark/hooks': resolve(projectRoot, 'src/lib/static-spark/hooks.ts'),
+    }
+  : {}
 
 // https://vite.dev/config/
 export default defineConfig({
@@ -37,6 +51,8 @@ export default defineConfig({
   ],
   resolve: {
     alias: {
+      // Spark runtime/hooks shims for the static Pages build (see above).
+      ...sparkPagesAliases,
       '@': resolve(projectRoot, 'src')
     }
   },


### PR DESCRIPTION
## Problem

PR #151 fixed Pages to serve the built `dist/` — but the built app still logged ~79 console errors on load at https://organvm.github.io/classroom-rpg-aetheria/, dominated by `405` and `404`. These are GitHub Spark **runtime** requests that have no backend on a static Pages host:

| Request | Status | Source | Fires |
|---|---|---|---|
| `POST /_spark/loaded` | 405 | `import "@github/spark/spark"` beacon (`main.tsx:5`) | on load |
| `GET /_spark/kv` + `GET /_spark/kv/<key>` | 404 | every `useKV` from `@github/spark/hooks` on mount (~12 hooks/contexts) | on load |
| `GET /_spark/user` | 404 | `window.spark.user()` | on demand |
| `POST /_spark/llm` | 405 | `window.spark.llm()` (quest eval / content gen) | user action |

The ~79 count = the single `/_spark/loaded` 405 plus the fan-out of `/_spark/kv` GETs (a keys-list + per-key fetch) across every mounted `useKV` (`use-theme`, `GameStateContext`, `use-voting`, `use-thematic-variants`, `use-standards`, `use-feedback-snippets`, `TeacherDashboard`, `SyllabusManager`, etc.).

## Fix — dead-code-eliminate the requests at build time (not try/catch)

When `GITHUB_PAGES` is set, `vite.config.ts` `resolve.alias` swaps the two Spark module specifiers for network-free, localStorage-backed shims, so the real Spark network code is **never bundled**:

- `@github/spark/spark` → `src/lib/static-spark/spark.ts` — installs `window.spark` with a localStorage `kv`, a static anonymous `user`, and a graceful `llm`/`llmPrompt` (no beacon, no `/_spark/*` fetch)
- `@github/spark/hooks` → `src/lib/static-spark/hooks.ts` — `useKV` with the identical signature, backed by `localStorage` (cross-tab sync via the `storage` event)

Normal/dev builds are untouched (alias only applies when `GITHUB_PAGES` is set) and keep the real Spark runtime. This covers all ~12 `useKV` call sites without editing each one.

**Already-dormant (not touched):** Firebase (`isFirebaseConfigured()` false → no init/auth on static), Sentry (`VITE_SENTRY_DSN` gate), Web-Vitals (same gate). The Firebase-auth `/__cookies__` fetch and the react-three-fiber `/api/objects` string are non-issues (auth is never initialized; the latter is a doc-URL in a warning message).

## Verification

```
GITHUB_PAGES=true pnpm run build   → ✓ built (7173 modules)

grep '/_spark/' dist/assets/index-*.js   → 0 matches   (loaded/kv/user/llm all gone)
grep 'spark-kv:'  dist/assets/index-*.js → present     (localStorage shim bundled)
```

Every doomed on-load request is eliminated from the built bundle. Expected result on the live site after deploy: **0 spark-runtime console errors**.

### Categories guarded + counts
- `POST /_spark/loaded` beacon: 1 (on-load 405) — **removed**
- `GET /_spark/kv` + `/_spark/kv/<key>`: ~12 `useKV` mount fan-out (on-load 404s, the bulk of the ~79) — **removed**, now localStorage
- `GET /_spark/user`: 1 (on-demand 404) — **removed**, static identity
- `POST /_spark/llm`: 3 call sites (user-action 405) — **removed**, graceful fallback

None are genuinely unavailable-but-required: KV persists locally per visitor; AI features (which truly need a backend) degrade to a clear "unavailable on the static demo" message instead of erroring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)